### PR TITLE
feat : 입력된 요일로 날짜 산정해 예약하기

### DIFF
--- a/src/main/java/dbdip/demo/reservation/ReservationController.java
+++ b/src/main/java/dbdip/demo/reservation/ReservationController.java
@@ -26,6 +26,17 @@ public class ReservationController {
 
         return new ResponseEntity<>("Reservation created successfully", HttpStatus.CREATED);
     }
+    @PostMapping("/day")
+    public ResponseEntity<String> createReservationByDay(
+            @RequestParam("userId") Integer userId,
+            @RequestParam("expertId") Integer expertId,
+            @RequestParam("reservDay") Integer reservDay,
+            @RequestParam("reservTime") Integer reservTime
+    ) {
+        reservationService.createReservationByDay(userId, expertId, reservDay, reservTime);
+
+        return new ResponseEntity<>("Reservation created successfully", HttpStatus.CREATED);
+    }
     @GetMapping // OK
     public ResponseEntity<List<ReservationDto>> getAllReservationByUser(
             @RequestParam("userId") Integer userId

--- a/src/main/java/dbdip/demo/reservation/ReservationService.java
+++ b/src/main/java/dbdip/demo/reservation/ReservationService.java
@@ -15,7 +15,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,6 +35,27 @@ public class ReservationService {
         Experts expert = expertsRepository.findById(expertId).orElse(null);
 
         if (user != null && expert != null) {
+            final Reservation reservation = Reservation.builder()
+                    .users(user)
+                    .experts(expert)
+                    .reservDate(reservDate)
+                    .reservTime(reservTime)
+                    .build();
+
+            reservationRepository.save(reservation);
+        }
+    }
+    @Transactional
+    public void createReservationByDay(Integer userId, Integer expertId, Integer reservDay, Integer reservTime) {
+        Users user = usersRepository.findById(userId).orElse(null);
+        Experts expert = expertsRepository.findById(expertId).orElse(null);
+
+        if (user != null && expert != null) {
+            LocalDate today = LocalDate.now();
+            DayOfWeek desiredDay = DayOfWeek.of(reservDay);
+
+            LocalDate reservDate = today.with(TemporalAdjusters.nextOrSame(desiredDay));
+
             final Reservation reservation = Reservation.builder()
                     .users(user)
                     .experts(expert)


### PR DESCRIPTION

**엔드포인트:** 
```
POST /reservation/day
```

**설명:** 
특정 요일에 예약을 생성하는 API 엔드포인트입니다.

**Request Parameters:**

- `userId` (Integer): 예약을 생성할 사용자의 ID
- `expertId` (Integer): 예약을 생성할 전문가의 ID
- `reservDay` (Integer): 예약을 생성할 요일 (1부터 7까지의 값, 1은 월요일, 7은 일요일)
- `reservTime` (Integer): 예약 시간 (예: 9는 9시)

**Response:**

- **Success:** 
  - `201 Created` 상태 코드
  - 본문에 "Reservation created successfully" 메시지 포함

- **Failure:**
  - 에러가 발생한 경우 적절한 HTTP 상태 코드와 에러 메시지를 반환합니다.

**예시 요청:**
```json
POST /reservation/day?userId=123&expertId=456&reservDay=3&reservTime=10
```

**예시 응답:**
```json
201 Created
"Reservation created successfully"
```

**오류 응답:**
```json
400 Bad Request
{
    "error": "Invalid reservDay value. Please provide a value between 1 and 7."
}
```
